### PR TITLE
[SCRUM-31] Implement tournament creation flowImplement tournament creation flow and tests

### DIFF
--- a/src/app/[locale]/tournaments/page.tsx
+++ b/src/app/[locale]/tournaments/page.tsx
@@ -1,48 +1,54 @@
 import { TournamentsList } from "@/components/tournament/TournamentList";
+import { CreateTournamentButton } from "@/components/tournament/CreateTournamentButton";
 import { Option, None, Some } from "@/lib/option";
 import { fetchServerside } from "@/lib/utils";
-import { User } from "@/types/User";
 import { getTranslations } from "next-intl/server";
 import { cookies } from "next/headers";
 import { Link } from "@/i18n/navigation";
 import { redirect } from "next/navigation";
+import { User, UUID_MAX } from "@/types/User";
 
 export default async function TournamentListPage() {
   const t = await getTranslations("tournaments_list");
   let data_authme: Option<User> = new None();
+
   const res_authme = await fetchServerside("/auth/me", {
     headers: {
       Cookie: (await cookies()).toString(),
     },
   });
+
   if (res_authme.ok) {
     data_authme = new Some(await res_authme.json());
   }
 
   if (data_authme instanceof Some) {
     return (
-      <>
-        <div className="flex flex-col w-full h-screen items-center">
-          <h1 className="mt-8 sm:mt-16 text-2xl sm:text-4xl text-balance text-center font-semibold">
-            {t("welcome", { handle: data_authme.value.handle })}
-          </h1>
-          <p className="text-stone-500 text-xs text-balance text-center sm:text-base">
-            {t("heading")}
-          </p>
-          <TournamentsList />
-          <p className="text-stone-500 pt-2 mb-16 text-balance text-center">
-            {t.rich("login_redirect_footer", {
-              login: (chunks) => (
-                <Link href={"/login"} className="underline">
-                  {chunks}
-                </Link>
-              ),
-            })}
-          </p>
-        </div>
-      </>
+      <div className="flex flex-col w-full h-screen items-center">
+        <h1 className="mt-8 sm:mt-16 text-2xl sm:text-4xl text-balance text-center font-semibold">
+          {t("welcome", { handle: data_authme.value.handle })}
+        </h1>
+
+        <p className="text-stone-500 text-xs text-balance text-center sm:text-base">
+          {t("heading")}
+        </p>
+
+        {data_authme.value.id === UUID_MAX && <CreateTournamentButton />}
+
+        <TournamentsList />
+
+        <p className="text-stone-500 pt-2 mb-16 text-balance text-center">
+          {t.rich("login_redirect_footer", {
+            login: (chunks) => (
+              <Link href="/login" className="underline">
+                {chunks}
+              </Link>
+            ),
+          })}
+        </p>
+      </div>
     );
-  } else {
-    redirect("/login");
   }
+
+  redirect("/login");
 }

--- a/src/components/tournament/CreateTournamentButton.tsx
+++ b/src/components/tournament/CreateTournamentButton.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useActionState, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { createTournament } from "./actions";
+
+const initialState = {
+  success: false,
+  error: null as string | null,
+};
+
+export function CreateTournamentButton() {
+  const [open, setOpen] = useState(false);
+  const router = useRouter();
+
+  const [state, formAction, isPending] = useActionState(
+    createTournament,
+    initialState
+  );
+
+  useEffect(() => {
+    if (state.success) {
+      setOpen(false);
+      router.refresh();
+    }
+  }, [state.success, router]);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center rounded-md bg-white/10 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/20"
+      >
+        Create tournament
+      </button>
+
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4">
+          <div className="w-full max-w-md rounded-xl border border-white/10 bg-neutral-900 p-6 shadow-xl">
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="text-xl font-semibold text-white">
+                Create tournament
+              </h2>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="text-sm text-stone-400 hover:text-white"
+              >
+                Close
+              </button>
+            </div>
+
+            <form action={formAction} className="flex flex-col gap-4">
+           <div className="flex flex-col">
+  <label
+    htmlFor="full_name"
+    className="mb-1 text-sm text-stone-300"
+  >
+    Full name
+  </label>
+  <input
+    id="full_name"
+    type="text"
+    name="full_name"
+    required
+    className="rounded-md bg-white/10 px-3 py-2 text-sm text-white outline-none focus:ring-2 focus:ring-white/30"
+  />
+</div>
+
+<div className="flex flex-col">
+  <label
+    htmlFor="shortened_name"
+    className="mb-1 text-sm text-stone-300"
+  >
+    Short name
+  </label>
+  <input
+    id="shortened_name"
+    type="text"
+    name="shortened_name"
+    required
+    className="rounded-md bg-white/10 px-3 py-2 text-sm text-white outline-none focus:ring-2 focus:ring-white/30"
+  />
+</div>
+
+              {state.error && (
+                <p className="text-sm text-red-400">{state.error}</p>
+              )}
+
+              <button
+                type="submit"
+                disabled={isPending}
+                className="mt-2 rounded-md bg-white/20 px-4 py-2 text-sm font-medium text-white hover:bg-white/30 disabled:opacity-50"
+              >
+                {isPending ? "Creating..." : "Create"}
+              </button>
+            </form>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/tournament/TournamentList.tsx
+++ b/src/components/tournament/TournamentList.tsx
@@ -7,11 +7,12 @@ import MOW2024OlekRelief from "../../../public/S-MOW2024-olekrelief.jpg";
 
 const TournamentsList = async () => {
   let data_tournaments: Tournament[] = [];
-  const res = await fetchServerside("/tournament", {
-    headers: {
-      Cookie: (await cookies()).toString(),
-    },
-  });
+ const res = await fetchServerside("/tournaments", {
+  cache: "no-store",
+  headers: {
+    Cookie: (await cookies()).toString(),
+  },
+});
   if (res.ok) {
     data_tournaments = await res.json();
   }

--- a/src/components/tournament/actions.ts
+++ b/src/components/tournament/actions.ts
@@ -1,0 +1,58 @@
+"use server";
+
+import { fetchServerside } from "@/lib/utils";
+import { cookies } from "next/headers";
+import { revalidatePath } from "next/cache";
+
+type CreateTournamentState = {
+  success: boolean;
+  error: string | null;
+};
+
+export async function createTournament(
+  _prevState: CreateTournamentState,
+  formData: FormData
+): Promise<CreateTournamentState> {
+  const full_name = formData.get("full_name");
+  const shortened_name = formData.get("shortened_name");
+
+  const res = await fetchServerside("/tournaments", {
+    method: "POST",
+    headers: {
+      Cookie: (await cookies()).toString(),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      full_name,
+      shortened_name,
+      speech_time: 300,
+      end_protected_time: 30,
+      start_protected_time: 0,
+      ad_vocem_time: 60,
+      debate_time_slot: 120,
+      debate_preparation_time: 15,
+      beep_on_speech_end: true,
+      beep_on_protected_time: true,
+      visualize_protected_time: false,
+    }),
+  });
+
+  if (!res.ok) {
+    const errorText = await res.text();
+    console.error("Create tournament failed");
+    console.error("Status:", res.status);
+    console.error("Response:", errorText);
+
+    return {
+      success: false,
+      error: "Failed to create tournament.",
+    };
+  }
+
+  revalidatePath("/tournaments");
+
+  return {
+    success: true,
+    error: null,
+  };
+}

--- a/test/tournament.test.ts
+++ b/test/tournament.test.ts
@@ -1,0 +1,86 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("tournament creation", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/en/login");
+
+    await page
+      .getByRole("textbox", { name: "Your handle (username)" })
+      .fill("admin");
+
+    await page
+      .getByRole("textbox", { name: "Your password" })
+      .fill("admin");
+
+    await page.getByRole("button", { name: "Log in" }).click();
+
+    await page.waitForURL("/en/tournaments");
+  });
+
+  test("admin sees create tournament button", async ({ page }) => {
+    const button = page.getByRole("button", { name: "Create tournament" });
+    await expect(button).toBeVisible();
+  });
+
+  test("opens create tournament modal", async ({ page }) => {
+    await page.getByRole("button", { name: "Create tournament" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Create tournament" })
+    ).toBeVisible();
+    await expect(page.getByLabel("Full name")).toBeVisible();
+    await expect(page.getByLabel("Short name")).toBeVisible();
+  });
+
+  test("creates tournament successfully", async ({ page }) => {
+    await page.getByRole("button", { name: "Create tournament" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Create tournament" })
+    ).toBeVisible();
+
+    const unique = Date.now();
+    const fullName = `Tournament ${unique}`;
+    const shortName = `T${unique}`;
+
+    await page.getByLabel("Full name").fill(fullName);
+    await page.getByLabel("Short name").fill(shortName);
+    await page.getByRole("button", { name: "Create", exact: true }).click();
+
+    await expect(page.getByText(fullName)).toBeVisible();
+  });
+
+  test("shows error when creating duplicate tournament", async ({ page }) => {
+    const unique = Date.now();
+    const fullName = `Tournament ${unique}`;
+    const shortName = `T${unique}`;
+
+    await page.getByRole("button", { name: "Create tournament" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Create tournament" })
+    ).toBeVisible();
+
+    await page.getByLabel("Full name").fill(fullName);
+    await page.getByLabel("Short name").fill(shortName);
+    await page.getByRole("button", { name: "Create", exact: true }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Create tournament" })
+    ).not.toBeVisible();
+
+    await expect(page.getByText(fullName)).toBeVisible();
+
+    await page.getByRole("button", { name: "Create tournament" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Create tournament" })
+    ).toBeVisible();
+
+    await page.getByLabel("Full name").fill(fullName);
+    await page.getByLabel("Short name").fill(shortName);
+    await page.getByRole("button", { name: "Create", exact: true }).click();
+
+    await expect(page.locator("form")).toContainText(/failed to create tournament/i);
+  });
+});


### PR DESCRIPTION
## What was done
- implemented tournament creation flow on frontend
- added Playwright tests for tournament creation
- handled duplicate creation failure case
- manually created and tested a non-admin user

## Validation
- Playwright tests passing
- non-admin user login tested successfully
- tournament creation flow validated
