### PR TITLE
Scrum 1 debates list implementation

### DIFF
--- a/src/app/[locale]/t/[path]/debates/page.tsx
+++ b/src/app/[locale]/t/[path]/debates/page.tsx
@@ -1,0 +1,28 @@
+import { DebatesList } from "@/components/tournament/DebatesList";
+import { getTranslations } from "next-intl/server";
+
+type DebatesPageProps = {
+  params: Promise<{
+    locale: string;
+    path: string;
+  }>;
+};
+
+export default async function DebatesPage({ params }: DebatesPageProps) {
+  const { path } = await params;
+  const t = await getTranslations("debates");
+
+  return (
+    <div className="flex w-full flex-col items-center">
+      <div className="mt-8 flex w-full flex-col px-8 sm:mt-16 lg:px-16">
+        <h1 className="text-center text-3xl font-semibold text-white sm:text-left">
+          {t("title")}
+        </h1>
+
+        <div className="mt-8 w-full">
+          <DebatesList tournamentId={path} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/t/[path]/layout.tsx
+++ b/src/app/[locale]/t/[path]/layout.tsx
@@ -25,7 +25,7 @@ export default async function TournamentLayout({
       Cookie: (await cookies()).toString(),
     },
   });
-  const res_tournament = await fetchServerside(`/tournament/${path}`, {
+  const res_tournament = await fetchServerside(`/tournaments/${path}`, {
     headers: {
       Cookie: (await cookies()).toString(),
     },

--- a/src/components/tournament/DebateListItem.tsx
+++ b/src/components/tournament/DebateListItem.tsx
@@ -1,0 +1,30 @@
+import { Link } from "@/i18n/navigation";
+import { Debate } from "@/types/Debate";
+import { GenericListItem } from "./GenericListItem";
+
+const DebateListItem = ({ debate }: { debate: Debate }) => {
+  const debateId = debate.id ?? debate.round_id;
+
+  return (
+    <Link
+      href={`/t/${debate.tournament_id}/debates/${debateId}`}
+      className="w-full"
+    >
+      <GenericListItem>
+        <div className="flex w-full flex-col gap-2">
+          <h2 className="text-lg font-semibold text-white">
+            Debate {debateId}
+          </h2>
+
+          <div className="flex flex-col gap-1 text-sm text-stone-400">
+            <p>Round: {debate.round_id}</p>
+            <p>Motion: {debate.motion_id}</p>
+            <p>Marshal: {debate.marshal_user_id}</p>
+          </div>
+        </div>
+      </GenericListItem>
+    </Link>
+  );
+};
+
+export { DebateListItem };

--- a/src/components/tournament/DebatesList.tsx
+++ b/src/components/tournament/DebatesList.tsx
@@ -1,0 +1,26 @@
+import { GenericList } from "./GenericList";
+import { DebateListItem } from "./DebateListItem";
+import { loadDebates } from "./debates-loader";
+
+const DebatesList = async ({ tournamentId }: { tournamentId: string }) => {
+  const { debates, loadError } = await loadDebates(tournamentId);
+
+  if (loadError) {
+    return <p className="text-sm text-red-400">Failed to load debates.</p>;
+  }
+
+  if (debates.length === 0) {
+    return <p className="text-stone-400">No debates found.</p>;
+  }
+
+  return (
+    <GenericList>
+      {debates.map((debate) => {
+        const key = debate.id ?? debate.round_id;
+        return <DebateListItem key={key} debate={debate} />;
+      })}
+    </GenericList>
+  );
+};
+
+export { DebatesList };

--- a/src/components/tournament/GenericList.tsx
+++ b/src/components/tournament/GenericList.tsx
@@ -1,0 +1,7 @@
+import { ReactNode } from "react";
+
+const GenericList = ({ children }: { children: ReactNode }) => {
+  return <div className="flex w-full flex-col gap-4">{children}</div>;
+};
+
+export { GenericList };

--- a/src/components/tournament/GenericListItem.tsx
+++ b/src/components/tournament/GenericListItem.tsx
@@ -1,0 +1,11 @@
+import { ReactNode } from "react";
+
+const GenericListItem = ({ children }: { children: ReactNode }) => {
+  return (
+    <div className="w-full rounded border border-stone-700 bg-stone-700/15 px-4 py-4 hover:bg-stone-700/25 transition-colors">
+      {children}
+    </div>
+  );
+};
+
+export { GenericListItem };

--- a/src/components/tournament/dashboard/DashSide.tsx
+++ b/src/components/tournament/dashboard/DashSide.tsx
@@ -3,7 +3,6 @@ import {
   LucideCastle,
   LucideFileClock,
   LucideFileImage,
-  LucideIcon,
   LucideLayoutDashboard,
   LucidePaintBucket,
   LucideScale,
@@ -14,16 +13,26 @@ import {
   LucideUsers,
   LucideWaypoints,
 } from "lucide-react";
+import { ComponentType } from "react";
 import { Link } from "@/i18n/navigation";
 import "@/i18n/language-utils";
 import { useTranslations } from "next-intl";
 import { DebatecoreLogo } from "@/components/debatecore/DebatecoreLogo";
 import { GrandaLogo } from "@/components/debatecore/GrandaLogo";
+import { IconDebate } from "@/components/icons/DebateIcon";
+
+type SidebarIconProps = {
+  className?: string;
+};
+
+const DebateSidebarIcon = ({ className }: SidebarIconProps) => {
+  return <IconDebate moreClass={className} />;
+};
 
 type DashSideLink = {
   name: string;
   href: string;
-  icon: LucideIcon;
+  icon: ComponentType<SidebarIconProps>;
   disabled?: boolean;
 };
 
@@ -40,6 +49,7 @@ const DashSide = ({
   path_highlight?: string;
 }) => {
   const t = useTranslations("dash");
+
   const links: DashSidebarLinks = [
     {
       catname: t("sidebar.tournament.catname"),
@@ -53,7 +63,13 @@ const DashSide = ({
           name: t("sidebar.tournament.ladder"),
           href: `/t/${tournament_path}/ladder`,
           icon: LucideBetweenHorizontalStart,
-          disabled: true,
+          disabled: false,
+        },
+        {
+          name: t("sidebar.tournament.debates"),
+          href: `/t/${tournament_path}/debates`,
+          icon: DebateSidebarIcon,
+          disabled: false,
         },
         {
           name: t("sidebar.tournament.standings"),
@@ -129,7 +145,7 @@ const DashSide = ({
 
   return (
     <div className="flex flex-col">
-      <div className="flex items-center pl-6 gap-4 h-20 border-b border-stone-700">
+      <div className="flex h-20 items-center gap-4 border-b border-stone-700 pl-6">
         <LucideWaypoints size={32} />
         <div className="mb-1">
           <GrandaLogo className="text-2xl" subtitle={false} />
@@ -139,35 +155,38 @@ const DashSide = ({
           </p>
         </div>
       </div>
-      <div className="flex flex-col gap-8 pt-4 px-4">
+
+      <div className="flex flex-col gap-8 px-4 pt-4">
         {links.map((category) => {
           return (
             <div
               className="flex flex-col gap-2 font-medium"
               key={category.catname}
             >
-              <p className="text-stone-500 text-sm pl-2">
+              <p className="pl-2 text-sm text-stone-500">
                 {category.catname.toUpperCase()}
               </p>
+
               {category.links.map((link) => {
+                const Icon = link.icon;
+                const isHighlighted = link.name === path_highlight;
+
                 return (
                   <Link
                     key={link.name}
-                    className={`flex flex-row items-center gap-2 border border-transparent hover:border-stone-700 hover:bg-stone-700/25 focus:border-stone-700 focus:bg-stone-700/25 text-stone-200 rounded py-1 px-2 ${
-                      link.name === path_highlight && "bg-stone-700/15"
-                    } ${link.disabled && "opacity-35"}`}
-                    href={link.disabled === true ? "" : link.href}
+                    className={`flex flex-row items-center gap-2 rounded border border-transparent px-2 py-1 text-stone-200 hover:border-stone-700 hover:bg-stone-700/25 focus:border-stone-700 focus:bg-stone-700/25 ${
+                      isHighlighted ? "bg-stone-700/15" : ""
+                    } ${link.disabled ? "opacity-35" : ""}`}
+                    href={link.disabled ? "" : link.href}
                     aria-disabled={link.disabled === true}
                   >
-                    <link.icon
-                      size={22}
-                      className={`${
-                        link.name === path_highlight
-                          ? "text-stone-400"
-                          : "text-stone-500"
-                      } font-light`}
+                    <Icon
+                      className={`h-[22px] w-[22px] ${
+                        isHighlighted ? "text-stone-400" : "text-stone-500"
+                      }`}
                     />
-                    <span className="tracking-tight font-geist font-medium">
+
+                    <span className="font-geist font-medium tracking-tight">
                       {link.name}
                     </span>
                   </Link>

--- a/src/components/tournament/debates-loader.ts
+++ b/src/components/tournament/debates-loader.ts
@@ -1,0 +1,34 @@
+import { fetchServerside } from "@/lib/utils";
+import { Debate } from "@/types/Debate";
+import { cookies } from "next/headers";
+
+type LoadDebatesResult = {
+  debates: Debate[];
+  loadError: boolean;
+};
+
+const loadDebates = async (
+  tournamentId: string,
+): Promise<LoadDebatesResult> => {
+  const res = await fetchServerside(`/tournaments/${tournamentId}/debates`, {
+    cache: "no-store",
+    headers: {
+      Cookie: (await cookies()).toString(),
+    },
+  });
+
+  if (!res.ok) {
+    return {
+      debates: [],
+      loadError: true,
+    };
+  }
+
+  return {
+    debates: await res.json(),
+    loadError: false,
+  };
+};
+
+export { loadDebates };
+export type { LoadDebatesResult };

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -71,7 +71,6 @@
     "title": "granda: Debate Tournament Planner",
     "description": "Computer aided debate tournament organizing experience enrichment."
   },
-  "ladder": {
   "debates": {
     "title": "Debates"
   }

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -12,6 +12,7 @@
         "catname": "tournament",
         "overview": "Overview",
         "ladder": "Tournament Ladder",
+        "debates": "Debates",
         "standings": "Tournament Standings"
       },
       "tournament_data": {
@@ -69,5 +70,25 @@
   "metadata": {
     "title": "granda: Debate Tournament Planner",
     "description": "Computer aided debate tournament organizing experience enrichment."
+  },
+  "ladder": {
+    "title": "Tournament Ladder",
+    "planning_title": "Tournament planning",
+    "planning_description": "Set the core parameters to generate the tournament ladder.",
+    "group_phase_rounds": "Group phase rounds",
+    "groups_count": "Groups count",
+    "advancing_teams": "Advancing teams",
+    "submit": "Plan tournament",
+    "submitting": "Planning...",
+    "placeholder_title": "Tournament ladder",
+    "placeholder_description": "Tournament ladder placeholder.",
+    "no_phases_error": "Failed to load tournament phases.",
+    "validation_positive_integer": "This value must be a positive integer.",
+    "validation_power_of_two": "Advancing teams must be a power of 2.",
+    "request_failed": "Failed to plan the tournament.",
+    "success": "Tournament planning submitted successfully."
+  },
+  "debates": {
+    "title": "Debates"
   }
 }

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -72,22 +72,6 @@
     "description": "Computer aided debate tournament organizing experience enrichment."
   },
   "ladder": {
-    "title": "Tournament Ladder",
-    "planning_title": "Tournament planning",
-    "planning_description": "Set the core parameters to generate the tournament ladder.",
-    "group_phase_rounds": "Group phase rounds",
-    "groups_count": "Groups count",
-    "advancing_teams": "Advancing teams",
-    "submit": "Plan tournament",
-    "submitting": "Planning...",
-    "placeholder_title": "Tournament ladder",
-    "placeholder_description": "Tournament ladder placeholder.",
-    "no_phases_error": "Failed to load tournament phases.",
-    "validation_positive_integer": "This value must be a positive integer.",
-    "validation_power_of_two": "Advancing teams must be a power of 2.",
-    "request_failed": "Failed to plan the tournament.",
-    "success": "Tournament planning submitted successfully."
-  },
   "debates": {
     "title": "Debates"
   }

--- a/src/types/Debate.ts
+++ b/src/types/Debate.ts
@@ -1,0 +1,9 @@
+type Debate = {
+  id?: string;
+  marshal_user_id: string;
+  motion_id: string;
+  round_id: string;
+  tournament_id: string;
+};
+
+export type { Debate };

--- a/src/types/Debate.ts
+++ b/src/types/Debate.ts
@@ -1,7 +1,7 @@
 type Debate = {
-  id?: string;
-  marshal_user_id: string;
-  motion_id: string;
+  id: string;
+  marshal_user_id?: string;
+  motion_id?: string;
   round_id: string;
   tournament_id: string;
 };

--- a/src/types/Phase.ts
+++ b/src/types/Phase.ts
@@ -1,0 +1,11 @@
+type Phase = {
+  id: string;
+  name: string;
+  tournament_id: string;
+  previous_phase_id?: string;
+  group_size?: number;
+  is_finals: boolean;
+  status: "Planned" | "Ongoing" | "Finished";
+};
+
+export type { Phase };

--- a/test/e2e/tournament.test.ts
+++ b/test/e2e/tournament.test.ts
@@ -1,0 +1,119 @@
+import { expect } from "@playwright/test";
+import { test } from "./e2eUtils";
+
+test.describe("tournament creation", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/en/login");
+
+    await page
+      .getByRole("textbox", { name: "Your handle (username)" })
+      .fill("admin");
+
+    await page.getByRole("textbox", { name: "Your password" }).fill("admin");
+
+    await page.getByRole("button", { name: "Log in" }).click();
+
+    await page.waitForURL("/en/tournaments");
+  });
+
+  test("admin sees create tournament button", async ({ page }) => {
+    const button = page.getByRole("button", { name: "Create tournament" });
+    await expect(button).toBeVisible();
+  });
+
+  test("opens create tournament modal", async ({ page }) => {
+    await page.getByRole("button", { name: "Create tournament" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Create tournament" }),
+    ).toBeVisible();
+    await expect(page.getByLabel("Full name")).toBeVisible();
+    await expect(page.getByLabel("Short name")).toBeVisible();
+  });
+
+  test("creates tournament successfully", async ({ page }) => {
+    await page.getByRole("button", { name: "Create tournament" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Create tournament" }),
+    ).toBeVisible();
+
+    const unique = Date.now();
+    const fullName = `Tournament ${unique}`;
+    const shortName = `T${unique}`;
+
+    await page.getByLabel("Full name").fill(fullName);
+    await page.getByLabel("Short name").fill(shortName);
+    await page.getByRole("button", { name: "Create", exact: true }).click();
+
+    await expect(page.getByText(fullName)).toBeVisible();
+  });
+
+  test("shows error when creating duplicate tournament", async ({ page }) => {
+    const unique = Date.now();
+    const fullName = `Tournament ${unique}`;
+    const shortName = `T${unique}`;
+
+    await page.getByRole("button", { name: "Create tournament" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Create tournament" }),
+    ).toBeVisible();
+
+    await page.getByLabel("Full name").fill(fullName);
+    await page.getByLabel("Short name").fill(shortName);
+    await page.getByRole("button", { name: "Create", exact: true }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Create tournament" }),
+    ).not.toBeVisible();
+
+    await expect(page.getByText(fullName)).toBeVisible();
+
+    await page.getByRole("button", { name: "Create tournament" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Create tournament" }),
+    ).toBeVisible();
+
+    await page.getByLabel("Full name").fill(fullName);
+    await page.getByLabel("Short name").fill(shortName);
+    await page.getByRole("button", { name: "Create", exact: true }).click();
+
+    await expect(page.locator("form")).toContainText(
+      /failed to create tournament/i,
+    );
+  });
+
+  test("sidebar contains debates link", async ({ page }) => {
+    await page.getByRole("button", { name: "Create tournament" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Create tournament" }),
+    ).toBeVisible();
+
+    const unique = Date.now();
+    const fullName = `Tournament ${unique}`;
+    const shortName = `T${unique}`;
+
+    await page.getByLabel("Full name").fill(fullName);
+    await page.getByLabel("Short name").fill(shortName);
+    await page.getByRole("button", { name: "Create", exact: true }).click();
+
+    const tournamentLink = page
+      .locator("a")
+      .filter({ hasText: fullName })
+      .first();
+    await expect(tournamentLink).toBeVisible();
+
+    await tournamentLink.click();
+    await page.waitForURL(/\/en\/t\/[^/]+$/);
+
+    const debatesLink = page.locator('a[href$="/debates"]').first();
+    await expect(debatesLink).toBeVisible();
+    await expect(debatesLink).toHaveAttribute(
+      "href",
+      /\/en\/t\/[^/]+\/debates$/,
+    );
+  });
+});

--- a/test/unit-tests/debates-loader.test.ts
+++ b/test/unit-tests/debates-loader.test.ts
@@ -1,0 +1,80 @@
+import { loadDebates } from "@/components/tournament/debates-loader";
+import { fetchServerside } from "@/lib/utils";
+import { cookies } from "next/headers";
+
+jest.mock("@/lib/utils", () => ({
+  fetchServerside: jest.fn(),
+}));
+
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(),
+}));
+
+const mockedFetchServerside = fetchServerside as jest.MockedFunction<
+  typeof fetchServerside
+>;
+const mockedCookies = cookies as jest.Mock;
+
+describe("loadDebates", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockedCookies.mockResolvedValue({
+      toString: () => "session=test-cookie",
+    });
+  });
+
+  test("should call debates endpoint and return debates when backend responds with ok", async () => {
+    mockedFetchServerside.mockResolvedValue({
+      ok: true,
+      json: async () => [
+        {
+          id: "debate-1",
+          marshal_user_id: "marshal-1",
+          motion_id: "motion-1",
+          round_id: "round-1",
+          tournament_id: "tournament-1",
+        },
+      ],
+    } as Response);
+
+    const result = await loadDebates("tournament-1");
+
+    expect(mockedFetchServerside).toHaveBeenCalledTimes(1);
+    expect(mockedFetchServerside).toHaveBeenCalledWith(
+      "/tournaments/tournament-1/debates",
+      {
+        cache: "no-store",
+        headers: {
+          Cookie: "session=test-cookie",
+        },
+      },
+    );
+
+    expect(result).toEqual({
+      debates: [
+        {
+          id: "debate-1",
+          marshal_user_id: "marshal-1",
+          motion_id: "motion-1",
+          round_id: "round-1",
+          tournament_id: "tournament-1",
+        },
+      ],
+      loadError: false,
+    });
+  });
+
+  test("should return loadError when backend responds with non-ok status", async () => {
+    mockedFetchServerside.mockResolvedValue({
+      ok: false,
+    } as Response);
+
+    const result = await loadDebates("tournament-1");
+
+    expect(result).toEqual({
+      debates: [],
+      loadError: true,
+    });
+  });
+});


### PR DESCRIPTION
**Description**

Implemented the debates list page for tournaments.

Changes included:
- added a new debates route under `/[locale]/t/[path]/debates`
- added the debates entry to the tournament sidebar
- created generic list components for reusable list rendering
- created debate-specific list components
- added a debate loader for fetching tournament debates
- added the `Debate` type
- updated automated tests for the new functionality
- adjusted the ladder actions unit test to match the current endpoint

**Testing**

- [x] I have covered code introduced by this pull request with tests.
- [x] I have run all tests with `npm test && npx playwright test` and ensured that they pass consistently.
