### PR TITLE
Refactor DebatesList UI to match the new design

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "granda-front",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "granda-front",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@radix-ui/react-dropdown-menu": "^2.1.6",
         "@radix-ui/react-select": "^2.2.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11269,16 +11269,6 @@
         }
       }
     },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@radix-ui/react-dropdown-menu": "^2.1.6",
         "@radix-ui/react-select": "^2.2.6",
+        "@swc/helpers": "^0.5.21",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "flag-icons": "^7.5.0",
@@ -3781,9 +3782,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -11267,6 +11268,15 @@
         "@swc/helpers": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next/node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.6",
     "@radix-ui/react-select": "^2.2.6",
+    "@swc/helpers": "^0.5.21",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "flag-icons": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "granda-front",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "granda-front",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/components/tournament/DebateListItem.tsx
+++ b/src/components/tournament/DebateListItem.tsx
@@ -5,23 +5,17 @@ import { GenericListItem } from "./GenericListItem";
 const DebateListItem = ({ debate }: { debate: Debate }) => {
   const debateId = debate.id ?? debate.round_id;
 
+  const motion = debate.motion_id || `Debate ${debateId}`;
+  const displayTitle =
+    motion.length > 60 ? `${motion.substring(0, 57)}...` : motion;
+
   return (
     <Link
       href={`/t/${debate.tournament_id}/debates/${debateId}`}
       className="w-full"
     >
-      <GenericListItem>
-        <div className="flex w-full flex-col gap-2">
-          <h2 className="text-lg font-semibold text-white">
-            Debate {debateId}
-          </h2>
-
-          <div className="flex flex-col gap-1 text-sm text-stone-400">
-            <p>Round: {debate.round_id}</p>
-            <p>Motion: {debate.motion_id}</p>
-            <p>Marshal: {debate.marshal_user_id}</p>
-          </div>
-        </div>
+      <GenericListItem title={displayTitle}>
+        <span>Round: {debate.round_id}</span>
       </GenericListItem>
     </Link>
   );

--- a/src/components/tournament/GenericList.tsx
+++ b/src/components/tournament/GenericList.tsx
@@ -1,7 +1,25 @@
 import { ReactNode } from "react";
+import { LucideIcon } from "lucide-react";
 
-const GenericList = ({ children }: { children: ReactNode }) => {
-  return <div className="flex w-full flex-col gap-4">{children}</div>;
+type GenericListProps = {
+  children: ReactNode;
+  icon?: LucideIcon;
+};
+
+const GenericList = ({ children, icon: ICON }: GenericListProps) => {
+  return (
+    <div className="flex w-full flex-col gap-6">
+      <div className="flex w-full flex-col gap-3">
+        {ICON && (
+          <div className="flex h-8 w-8 items-center justify-center rounded bg-pink-500 text-white">
+            <ICON size={20} />
+          </div>
+        )}
+      </div>
+
+      <div className="flex w-full flex-col gap-4">{children}</div>
+    </div>
+  );
 };
 
 export { GenericList };

--- a/src/components/tournament/GenericListItem.tsx
+++ b/src/components/tournament/GenericListItem.tsx
@@ -1,9 +1,18 @@
 import { ReactNode } from "react";
 
-const GenericListItem = ({ children }: { children: ReactNode }) => {
+type GenericListProps = {
+  title: string;
+  children: ReactNode;
+};
+
+const GenericListItem = ({ title, children }: GenericListProps) => {
   return (
     <div className="w-full rounded border border-stone-700 bg-stone-700/15 px-4 py-4 hover:bg-stone-700/25 transition-colors">
-      {children}
+      <div className="text-lg font-medium text-white mb-1">{title}</div>
+
+      <div className="flex flex-row items-center gap-x-4 text-sm text-stone-400">
+        {children}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
I have finished updating the DebatesList UI to match the new design.

Key Changes:

- GenericList: Added support for the pink icon box.
- GenericListItem: Implemented a two-row layout (Title on top, Meta info on bottom).

DebateListItem: Updated to show the Motion as the title with a truncation logic (max 60 chars) and the Round ID below it.
(Note: phase_name is currently omitted as we discussed.)

Testing:
Since I couldn't find a tournament with existing debate data in the local environment, I temporarily injected dummy data into DebatesList.tsx to verify the UI and the truncation logic. I have already reverted those test changes.

Screenshots:
<img width="1470" height="833" alt="スクリーンショット 2026-05-11 19 47 51" src="https://github.com/user-attachments/assets/a9df0404-2b8f-4b68-abad-27a57a8bd682" />

Please let me know if any further adjustments are needed!
