### PR TITLE
Scrum 83 user tutorial component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "granda-front",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "granda-front",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "dependencies": {
         "@radix-ui/react-dropdown-menu": "^2.1.6",
         "@radix-ui/react-select": "^2.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "granda-front",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/components/icons/QuestionIcon.tsx
+++ b/src/components/icons/QuestionIcon.tsx
@@ -1,0 +1,23 @@
+import { iconprops } from "@/types/iconprops";
+
+const IconQuestion = (props: iconprops) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill={props.fill ? "currentColor" : "none"}
+      stroke="currentColor"
+      strokeWidth={props.strokeWidth || 2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={`feather ${props.moreClass || ""}`.trim()}
+    >
+      <circle cx="12" cy="12" r="10"></circle>
+      <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3M12 17h.01"></path>
+    </svg>
+  );
+};
+
+export { IconQuestion };

--- a/src/components/icons/TutorialIcon.tsx
+++ b/src/components/icons/TutorialIcon.tsx
@@ -1,0 +1,23 @@
+import { iconprops } from "@/types/iconprops";
+
+const IconTutorial = (props: iconprops) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill={props.fill ? "currentColor" : "none"}
+      stroke="currentColor"
+      strokeWidth={props.strokeWidth || 2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={`feather ${props.moreClass || ""}`.trim()}
+    >
+      <path d="M21.42 10.922a1 1 0 0 0-.019-1.838L12.83 5.18a2 2 0 0 0-1.66 0L2.6 9.08a1 1 0 0 0 0 1.832l8.57 3.908a2 2 0 0 0 1.66 0zM22 10v6" />
+      <path d="M6 12.5V16a6 3 0 0 0 12 0v-3.5" />
+    </svg>
+  );
+};
+
+export { IconTutorial };

--- a/src/components/ui/HintButton.tsx
+++ b/src/components/ui/HintButton.tsx
@@ -7,10 +7,10 @@ import { HintTextBox } from "./HintTextBox";
 interface HintButtonProps {
   title: string;
   content: string;
-  pointerDirection: "top" | "bottom" | "left" | "right";
+  boxPosition: "top" | "bottom" | "left" | "right";
 }
 
-const HintButton = ({ title, content, pointerDirection }: HintButtonProps) => {
+const HintButton = ({ title, content, boxPosition }: HintButtonProps) => {
   const [showTutorial, setShowTutorial] = useState(false);
 
   const textBoxPlacement = {
@@ -28,12 +28,12 @@ const HintButton = ({ title, content, pointerDirection }: HintButtonProps) => {
         <IconQuestion />
       </button>
 
-      <div className={`absolute z-50 ${textBoxPlacement[pointerDirection]}`}>
+      <div className={`absolute z-50 ${textBoxPlacement[boxPosition]}`}>
         <HintTextBox
           title={title}
           content={content}
           visible={showTutorial}
-          pointerDirection={pointerDirection}
+          boxPosition={boxPosition}
           onDismiss={() => setShowTutorial(false)}
         />
       </div>

--- a/src/components/ui/HintButton.tsx
+++ b/src/components/ui/HintButton.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { IconQuestion } from "../icons/QuestionIcon";
+import { useState } from "react";
+import { HintTextBox } from "./HintTextBox";
+
+interface HintButtonProps {
+  title: string;
+  content: string;
+  pointerDirection: "top" | "bottom" | "left" | "right";
+}
+
+const HintButton = ({ title, content, pointerDirection }: HintButtonProps) => {
+  const [showTutorial, setShowTutorial] = useState(false);
+
+  const textBoxPlacement = {
+    top: "bottom-full left-1/2 -translate-x-1/2 mb-[10px]",
+    bottom: "top-full left-1/2 -translate-x-1/2 mt-[10px]",
+    left: "right-full top-1/2 -translate-y-1/2 mr-[10px]",
+    right: "left-full top-1/2 -translate-y-1/2 ml-[10px]",
+  };
+  return (
+    <div className="relative inline-block">
+      <button
+        className="flex items-center justify-center p-[8px] bg-transparent hover:cursor-pointer"
+        onClick={() => setShowTutorial(!showTutorial)}
+      >
+        <IconQuestion />
+      </button>
+
+      <div
+        className={`absolute w-max z-50 ${textBoxPlacement[pointerDirection]}`}
+      >
+        <HintTextBox
+          title={title}
+          content={content}
+          visible={showTutorial}
+          pointerDirection={pointerDirection}
+          onDismiss={() => setShowTutorial(false)}
+        />
+      </div>
+    </div>
+  );
+};
+
+export { HintButton };

--- a/src/components/ui/HintButton.tsx
+++ b/src/components/ui/HintButton.tsx
@@ -20,17 +20,15 @@ const HintButton = ({ title, content, pointerDirection }: HintButtonProps) => {
     right: "left-full top-1/2 -translate-y-1/2 ml-[10px]",
   };
   return (
-    <div className="relative inline-block">
+    <div className="z-50 relative inline-block">
       <button
-        className="flex items-center justify-center p-[8px] bg-transparent hover:cursor-pointer"
+        className="flex items-center justify-center p-[8px] bg-transparent hover:cursor-pointer focus:outline-none"
         onClick={() => setShowTutorial(!showTutorial)}
       >
         <IconQuestion />
       </button>
 
-      <div
-        className={`absolute w-max z-50 ${textBoxPlacement[pointerDirection]}`}
-      >
+      <div className={`absolute z-50 ${textBoxPlacement[pointerDirection]}`}>
         <HintTextBox
           title={title}
           content={content}

--- a/src/components/ui/HintTextBox.tsx
+++ b/src/components/ui/HintTextBox.tsx
@@ -1,0 +1,27 @@
+type HintTextBoxProps = {
+  title: string;
+  content: string;
+  onClose: () => void;
+};
+
+const HintTextBox = (props: HintTextBoxProps) => {
+  return (
+    <div
+      className="
+        relative inline-block flex-wrap align-top text-justify bg-[#ffffff] leading-[18px] min-w-[280px] max-w-[320px] p-[20px] mb-[16px] rounded-lg overflow-wrap
+        
+        after:content-[''] after:absolute after:top-full after:left-1/2 after:-ml-[1em] after:w-0 after:h-0 after:border-t-[10px] after:border-x-[20px] after:-ml-[20px] after:border-transparent after:border-t-[#ffffff]"
+    >
+      <div className="text-[#333] text-[16px] font-bold pb-[10px]">
+        {props.title}
+      </div>
+      <div className="text-[#333] text-[12px]">{props.content}</div>
+      <div className="text-[#333] text-[12px] underline pt-[10px] text-right hover:cursor-pointer">
+        {" "}
+        OK{" "}
+      </div>
+    </div>
+  );
+};
+
+export { HintTextBox };

--- a/src/components/ui/HintTextBox.tsx
+++ b/src/components/ui/HintTextBox.tsx
@@ -1,24 +1,39 @@
-type HintTextBoxProps = {
+interface HintTextBoxProps {
   title: string;
   content: string;
-  onClose: () => void;
-};
+  pointerDirection?: "top" | "bottom" | "left" | "right";
+  visible: boolean;
+  onDismiss: () => void;
+}
 
-const HintTextBox = (props: HintTextBoxProps) => {
+const HintTextBox = ({
+  title,
+  content,
+  pointerDirection = "bottom",
+  visible,
+}: HintTextBoxProps) => {
+  if (!visible) return null;
+
+  const arrowPosition = {
+    top: "after:top-full after:border-t-[10px] after:border-x-[12px] after:left-1/2 after:-ml-[12px] after:border-t-[#ffffff] mb-[8px]",
+    bottom:
+      "after:bottom-full after:border-b-[10px] after:border-x-[12px] after:left-1/2 after:-ml-[12px] after:border-b-[#ffffff] mt-[8px]",
+    left: "after:left-full after:border-l-[10px] after:border-y-[12px] after:top-1/2 after:-mt-[12px] after:border-l-[#ffffff] mr-[8px]",
+    right:
+      "after:right-full after:border-r-[10px] after:border-y-[12px] after:top-1/2 after:-mt-[12px] after:border-r-[#ffffff] ml-[8px]",
+  };
+
   return (
     <div
-      className="
-        relative inline-block flex-wrap align-top text-justify bg-[#ffffff] leading-[18px] min-w-[280px] max-w-[320px] p-[20px] mb-[16px] rounded-lg overflow-wrap
+      className={`
+        relative inline-block flex-wrap align-top text-justify bg-[#ffffff] leading-[16px] min-w-[330px] max-w-[3400px] py-[18px] px-[24px] rounded-lg
         
-        after:content-[''] after:absolute after:top-full after:left-1/2 after:-ml-[1em] after:w-0 after:h-0 after:border-t-[10px] after:border-x-[20px] after:-ml-[20px] after:border-transparent after:border-t-[#ffffff]"
+        after:content-[''] after:absolute after:w-0 after:h-0 after:border-transparent ${arrowPosition[pointerDirection]}`}
     >
-      <div className="text-[#333] text-[16px] font-bold pb-[10px]">
-        {props.title}
-      </div>
-      <div className="text-[#333] text-[12px]">{props.content}</div>
-      <div className="text-[#333] text-[12px] underline pt-[10px] text-right hover:cursor-pointer">
-        {" "}
-        OK{" "}
+      <div className="text-[#333] text-[16px] font-bold pb-[10px]">{title}</div>
+      <div className="text-[#333] text-[12px]">{content}</div>
+      <div className="text-[#333] text-[12px] underline pt-[6px] text-right hover:cursor-pointer">
+        OK
       </div>
     </div>
   );

--- a/src/components/ui/HintTextBox.tsx
+++ b/src/components/ui/HintTextBox.tsx
@@ -1,3 +1,5 @@
+import { IconTutorial } from "@/components/icons/TutorialIcon";
+
 interface HintTextBoxProps {
   title: string;
   content: string;
@@ -11,6 +13,7 @@ const HintTextBox = ({
   content,
   pointerDirection = "bottom",
   visible,
+  onDismiss,
 }: HintTextBoxProps) => {
   if (!visible) return null;
 
@@ -26,14 +29,24 @@ const HintTextBox = ({
   return (
     <div
       className={`
-        relative inline-block flex-wrap align-top text-justify bg-[#ffffff] leading-[16px] min-w-[330px] max-w-[3400px] py-[18px] px-[24px] rounded-lg
+        relative inline-block flex-wrap align-top text-justify bg-[#ffffff] leading-[16px] min-w-[340px] py-[18px] px-[24px] rounded-md
         
         after:content-[''] after:absolute after:w-0 after:h-0 after:border-transparent ${arrowPosition[pointerDirection]}`}
     >
-      <div className="text-[#333] text-[16px] font-bold pb-[10px]">{title}</div>
-      <div className="text-[#333] text-[12px]">{content}</div>
-      <div className="text-[#333] text-[12px] underline pt-[6px] text-right hover:cursor-pointer">
-        OK
+      <div className="flex items-center justify-between select-none pb-[10px]">
+        <span className="text-[#333] text-[16px] font-bold pt-[2px]">
+          {title}
+        </span>
+        <IconTutorial moreClass="text-pink-500 w-[30px] h-[30px]" />{" "}
+      </div>
+      <div className="text-[#333] text-[12px] select-none">{content}</div>
+      <div className=" pt-[6px] text-right">
+        <span
+          className="text-[#333] text-[12px] underline hover:cursor-pointer select-none pd-[2px]"
+          onClick={onDismiss}
+        >
+          OK
+        </span>
       </div>
     </div>
   );

--- a/src/components/ui/HintTextBox.tsx
+++ b/src/components/ui/HintTextBox.tsx
@@ -3,7 +3,7 @@ import { IconTutorial } from "@/components/icons/TutorialIcon";
 interface HintTextBoxProps {
   title: string;
   content: string;
-  pointerDirection?: "top" | "bottom" | "left" | "right";
+  boxPosition: "top" | "bottom" | "left" | "right";
   visible: boolean;
   onDismiss: () => void;
 }
@@ -11,7 +11,7 @@ interface HintTextBoxProps {
 const HintTextBox = ({
   title,
   content,
-  pointerDirection = "bottom",
+  boxPosition,
   visible,
   onDismiss,
 }: HintTextBoxProps) => {
@@ -31,7 +31,7 @@ const HintTextBox = ({
       className={`
         relative inline-block flex-wrap align-top text-justify bg-[#ffffff] leading-[16px] min-w-[340px] py-[18px] px-[24px] rounded-md
         
-        after:content-[''] after:absolute after:w-0 after:h-0 after:border-transparent ${arrowPosition[pointerDirection]}`}
+        after:content-[''] after:absolute after:w-0 after:h-0 after:border-transparent ${arrowPosition[boxPosition]}`}
     >
       <div className="flex items-center justify-between select-none pb-[10px]">
         <span className="text-[#333] text-[16px] font-bold pt-[2px]">


### PR DESCRIPTION
## Description

- Created `HintTextBox` and `HintButton` components to display tutorial bubbles
- Added icon components: `QuestionIcon` and `TutorialIcon`

## Usage Example
`<HintButton title="Tutorial header" content="Maecenas elementum dignissim magna, eget tincidunt felis volutpat eu. Duis ut ullamcorper nibh. Morbi consequat, augue ac tristique bibendum, enim tellus gravida erat, at vestibulum arcu eros quis felis." boxPosition="bottom" />`

Results in:

<img width="480" height="344" alt="Zrzut ekranu 2026-05-26 111605" src="https://github.com/user-attachments/assets/9a52849d-d617-4418-8b40-705b72af109a" />

## Testing

- [ X ] I have covered code introduced by this pull request with tests.
- [ X ] I have run all tests with `npm run test && npx playwright test` and ensured that they pass consistently.
